### PR TITLE
Added https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ type HttpClient struct {
     ReadWriteTimeout time.Duration
     MaxConnsPerHost  int
     RedirectPolicy   func(*http.Request, []*http.Request) error
+    TLSClientConfig  *tls.Config
 }
 
 func New() *HttpClient
@@ -66,6 +67,10 @@ func main() {
     httpClient := httpclient.New()
     httpClient.ConnectTimeout = time.Second
     httpClient.ReadWriteTimeout = time.Second
+
+    // Allow insecure HTTPS connections.  Note: the TLSClientConfig pointer can't change
+    // places, so you can only modify the existing tls.Config object
+	httpClient.TLSClientConfig.InsecureSkipVerify = true
 
     // Make a custom redirect policy to keep track of the number of redirects we've followed
     var numRedirects int


### PR DESCRIPTION
The "hc_" hack was generalized to also work for https connections.  In
addition, there now exists a TLSClientConfig object within the
HttpClient object that can be used to control the TLS settings for HTTPS
connections.  One caviat is that the object cannot be moved anywhere in
memory, so it can only be changed inplace.
