### PR TITLE
Get() and Post() helpers are problematic

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,15 +30,9 @@ func (h *HttpClient) FinishRequest(req *http.Request) error
     every request performed after processing is finished and after which
     GetConn will no longer return successfully
 
-func (h *HttpClient) Get(url string) (*http.Response, error)
-    convenience method to perform a HTTP GET request
-
 func (h *HttpClient) GetConn(req *http.Request) (net.Conn, error)
     returns the connection associated with the specified request cannot be
     called after FinishRequest
-
-func (h *HttpClient) Post(url string, contentType string, body io.Reader) (*http.Response, error)
-    convenience method to perform a HTTP POST request
 
 func (h *HttpClient) RoundTrip(req *http.Request) (*http.Response, error)
     satisfies the RoundTripper interface and handles checking the connection

--- a/httpclient.go
+++ b/httpclient.go
@@ -5,7 +5,6 @@ import (
 	"container/list"
 	"crypto/tls"
 	"errors"
-	"io"
 	"log"
 	"net"
 	"net/http"
@@ -242,25 +241,6 @@ func (h *HttpClient) Do(req *http.Request) (*http.Response, error) {
 		}
 	}
 	return resp, err
-}
-
-// convenience method to perform a HTTP GET request
-func (h *HttpClient) Get(url string) (*http.Response, error) {
-	req, err := http.NewRequest("GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-	return h.Do(req)
-}
-
-// convenience method to perform a HTTP POST request
-func (h *HttpClient) Post(url string, contentType string, body io.Reader) (*http.Response, error) {
-	req, err := http.NewRequest("POST", url, body)
-	if err != nil {
-		return nil, err
-	}
-	req.Header.Set("Content-Type", contentType)
-	return h.Do(req)
 }
 
 // perform final cleanup for the specified request


### PR DESCRIPTION
if Get() or Post() are used, the user doesn't have access to the Request struct, and can't call FinishRequest()
