### PR TITLE
Add an IdleTimeout to the Transport

### DIFF
--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -43,12 +43,26 @@ func redirect2Handler(w http.ResponseWriter, req *http.Request) {
 	http.Redirect(w, req, "/redirect", 302)
 }
 
+func slowHandler(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	io.WriteString(w, "START\n")
+	f := w.(http.Flusher)
+	f.Flush()
+	time.Sleep(200 * time.Millisecond)
+	io.WriteString(w, "WORKING\n")
+	f.Flush()
+	time.Sleep(200 * time.Millisecond)
+	io.WriteString(w, "DONE\n")
+	return
+}
+
 func setupMockServer(t *testing.T) {
 	http.HandleFunc("/test", testHandler)
 	http.HandleFunc("/post", postHandler)
 	http.HandleFunc("/redirect", redirectHandler)
 	http.HandleFunc("/redirect2", redirect2Handler)
 	http.HandleFunc("/close", closeHandler)
+	http.HandleFunc("/slow", slowHandler)
 	ln, err := net.Listen("tcp", ":0")
 	if err != nil {
 		t.Fatalf("failed to listen - %s", err.Error())
@@ -95,8 +109,9 @@ func TestHttpClient(t *testing.T) {
 	starter.Do(func() { setupMockServer(t) })
 
 	transport := &Transport{
-		ConnectTimeout: 1 * time.Second,
-		RequestTimeout: 5 * time.Second,
+		ConnectTimeout:   1 * time.Second,
+		RequestTimeout:   5 * time.Second,
+		ReadWriteTimeout: 3 * time.Second,
 	}
 	client := &http.Client{Transport: transport}
 
@@ -113,29 +128,80 @@ func TestHttpClient(t *testing.T) {
 	transport.Close()
 
 	transport = &Transport{
-		ConnectTimeout: 25 * time.Millisecond,
-		RequestTimeout: 50 * time.Millisecond,
+		ConnectTimeout:   25 * time.Millisecond,
+		RequestTimeout:   50 * time.Millisecond,
+		ReadWriteTimeout: 50 * time.Millisecond,
 	}
 	client = &http.Client{Transport: transport}
 
 	req2, _ := http.NewRequest("GET", "http://"+addr.String()+"/test", nil)
 	resp, err = client.Do(req2)
 	if err == nil {
-		t.Fatalf("2nd request should have timed out")
+		t.Fatal("2nd request should have timed out")
 	}
 	transport.Close()
 
 	transport = &Transport{
-		ConnectTimeout: 25 * time.Millisecond,
-		RequestTimeout: 250 * time.Millisecond,
+		ConnectTimeout:   25 * time.Millisecond,
+		RequestTimeout:   250 * time.Millisecond,
+		ReadWriteTimeout: 250 * time.Millisecond,
 	}
 	client = &http.Client{Transport: transport}
 
 	req3, _ := http.NewRequest("GET", "http://"+addr.String()+"/test", nil)
 	resp, err = client.Do(req3)
 	if err != nil {
-		t.Fatalf("3nd request should not have timed out")
+		t.Fatal("3rd request should not have timed out")
 	}
+	resp.Body.Close()
+	transport.Close()
+}
+
+func TestSlowServer(t *testing.T) {
+	starter.Do(func() { setupMockServer(t) })
+
+	transport := &Transport{
+		ConnectTimeout:   25 * time.Millisecond,
+		RequestTimeout:   500 * time.Millisecond,
+		ReadWriteTimeout: 250 * time.Millisecond,
+	}
+
+	client := &http.Client{Transport: transport}
+
+	req, _ := http.NewRequest("GET", "http://"+addr.String()+"/slow", nil)
+	resp, err := client.Do(req)
+	if err != nil {
+		t.Fatalf("1st request failed - %s", err)
+	}
+	_, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("1st failed to read body - %s", err)
+	}
+	resp.Body.Close()
+	transport.Close()
+
+	transport = &Transport{
+		ConnectTimeout:   25 * time.Millisecond,
+		RequestTimeout:   500 * time.Millisecond,
+		ReadWriteTimeout: 100 * time.Millisecond,
+	}
+	client = &http.Client{Transport: transport}
+
+	req, _ = http.NewRequest("GET", "http://"+addr.String()+"/slow", nil)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("2nd request failed - %s", err)
+	}
+	_, err = ioutil.ReadAll(resp.Body)
+	netErr, ok := err.(net.Error)
+	if !ok {
+		t.Fatalf("2nd request dind't return a net.Error - %s", netErr)
+	}
+
+	if !netErr.Timeout() {
+		t.Fatalf("2nd request should have timed out - %s", netErr)
+	}
+
 	resp.Body.Close()
 	transport.Close()
 }
@@ -146,6 +212,7 @@ func TestMultipleRequests(t *testing.T) {
 	transport := &Transport{
 		ConnectTimeout:        1 * time.Second,
 		RequestTimeout:        5 * time.Second,
+		ReadWriteTimeout:      3 * time.Second,
 		ResponseHeaderTimeout: 400 * time.Millisecond,
 	}
 	client := &http.Client{Transport: transport}


### PR DESCRIPTION
Proposal for an IdleTimeout option on the httpclient.Transport.
- This allows finer control of the timeouts on the client, and gives the caller an actual timeout error when hit, vs the closed connection error returned after canceling the request.
- This obviously interferes with Keepalive connections. Not sure if it should disable them by default, or just note it in the documentation.
- I punted a bit on the tests -- really need to put in a slow-writer endpoint to test for the IdleTimeout specifically. 
