### PR TITLE
Fix read tcp i/o timeout on PUT operations with persistent connections

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -194,7 +194,7 @@ type rwTimeoutConn struct {
 }
 
 func (c *rwTimeoutConn) Read(b []byte) (int, error) {
-	err := c.TCPConn.SetReadDeadline(time.Now().Add(c.rwTimeout))
+	err := c.TCPConn.SetDeadline(time.Now().Add(c.rwTimeout))
 	if err != nil {
 		return 0, err
 	}
@@ -202,7 +202,7 @@ func (c *rwTimeoutConn) Read(b []byte) (int, error) {
 }
 
 func (c *rwTimeoutConn) Write(b []byte) (int, error) {
-	err := c.TCPConn.SetWriteDeadline(time.Now().Add(c.rwTimeout))
+	err := c.TCPConn.SetDeadline(time.Now().Add(c.rwTimeout))
 	if err != nil {
 		return 0, err
 	}


### PR DESCRIPTION
http PUT operations with persistent connections turn out to run a Read
in parallel with the Write doing the PUT.  Because the Read is
inactive the read timeout activates and closes the connection even
though the Write is proceeding just fine.

You can see this code if you look at net/http/transport.go where you
see in Transport.dialConn

	go pconn.readLoop()
	go pconn.writeLoop()

Which starts the reader and the writer simultaneously.

The fix for this is for httpclient to use a single deadline for both
read and write.  This meas that an IO idle timeout will only be caused
if both read AND write timeout which is probably what the user is
expecting, rather than if read OR write timeout.