### PR TITLE
add feature of set tcp send buffer or receive buffer.

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -100,13 +100,13 @@ type Transport struct {
 	// Write operation on the request connection.
 	ReadWriteTimeout time.Duration
 
-	// TcpWriteBufferSize, the size of the operating system's write
+	// TCPWriteBufferSize, the size of the operating system's write
 	// buffer associated with the connection.
-	TcpWriteBufferSize int
+	TCPWriteBufferSize int
 
-	// TcpReadBuffserSize, the size of the operating system's read
+	// TCPReadBuffserSize, the size of the operating system's read
 	// buffer associated with the connection.
-	TcpReadBuffserSize int
+	TCPReadBufferSize int
 
 	starter   sync.Once
 	transport *http.Transport
@@ -125,15 +125,15 @@ func (t *Transport) lazyStart() {
 				return nil, err
 			}
 
-			if t.TcpReadBuffserSize != 0 || t.TcpWriteBufferSize != 0 {
+			if t.TCPReadBufferSize != 0 || t.TCPWriteBufferSize != 0 {
 				if tcpCon, ok := c.(*net.TCPConn); ok {
-					if t.TcpWriteBufferSize != 0 {
-						if err = tcpCon.SetWriteBuffer(t.TcpWriteBufferSize); err != nil {
+					if t.TCPWriteBufferSize != 0 {
+						if err = tcpCon.SetWriteBuffer(t.TCPWriteBufferSize); err != nil {
 							return nil, err
 						}
 					}
-					if t.TcpReadBuffserSize != 0 {
-						if err = tcpCon.SetReadBuffer(t.TcpReadBuffserSize); err != nil {
+					if t.TCPReadBufferSize != 0 {
+						if err = tcpCon.SetReadBuffer(t.TCPReadBufferSize); err != nil {
 							return nil, err
 						}
 					}

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -112,8 +112,8 @@ func TestHttpClient(t *testing.T) {
 		ConnectTimeout:     1 * time.Second,
 		RequestTimeout:     5 * time.Second,
 		ReadWriteTimeout:   3 * time.Second,
-		TcpWriteBufferSize: 64 * 1024,
-		TcpReadBuffserSize: 64 * 1024,
+		TCPWriteBufferSize: 64 * 1024,
+		TCPReadBufferSize:  64 * 1024,
 	}
 	client := &http.Client{Transport: transport}
 

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -109,9 +109,11 @@ func TestHttpClient(t *testing.T) {
 	starter.Do(func() { setupMockServer(t) })
 
 	transport := &Transport{
-		ConnectTimeout:   1 * time.Second,
-		RequestTimeout:   5 * time.Second,
-		ReadWriteTimeout: 3 * time.Second,
+		ConnectTimeout:     1 * time.Second,
+		RequestTimeout:     5 * time.Second,
+		ReadWriteTimeout:   3 * time.Second,
+		TcpWriteBufferSize: 64 * 1024,
+		TcpReadBuffserSize: 64 * 1024,
 	}
 	client := &http.Client{Transport: transport}
 


### PR DESCRIPTION
add feature of set tcp send buffer or receive buffer.

This is an advanced option for advanced users who want
to tune low level TCP parameters to try and squeeze out more performance. Especially in the WAN environment.
