### PR TITLE
add feature of set tcp send buffer or receive buffer.

### DIFF
--- a/httpclient.go
+++ b/httpclient.go
@@ -12,6 +12,7 @@ package httpclient
 
 import (
 	"crypto/tls"
+	"errors"
 	"io"
 	"net"
 	"net/http"
@@ -99,6 +100,14 @@ type Transport struct {
 	// Write operation on the request connection.
 	ReadWriteTimeout time.Duration
 
+	// TCPWriteBufferSize, the size of the operating system's write
+	// buffer associated with the connection.
+	TCPWriteBufferSize int
+
+	// TCPReadBuffserSize, the size of the operating system's read
+	// buffer associated with the connection.
+	TCPReadBufferSize int
+
 	starter   sync.Once
 	transport *http.Transport
 }
@@ -114,6 +123,24 @@ func (t *Transport) lazyStart() {
 			c, err := net.DialTimeout(netw, addr, t.ConnectTimeout)
 			if err != nil {
 				return nil, err
+			}
+
+			if t.TCPReadBufferSize != 0 || t.TCPWriteBufferSize != 0 {
+				if tcpCon, ok := c.(*net.TCPConn); ok {
+					if t.TCPWriteBufferSize != 0 {
+						if err = tcpCon.SetWriteBuffer(t.TCPWriteBufferSize); err != nil {
+							return nil, err
+						}
+					}
+					if t.TCPReadBufferSize != 0 {
+						if err = tcpCon.SetReadBuffer(t.TCPReadBufferSize); err != nil {
+							return nil, err
+						}
+					}
+				} else {
+					err = errors.New("Not Tcp Connection")
+					return nil, err
+				}
 			}
 
 			if t.ReadWriteTimeout > 0 {

--- a/httpclient_test.go
+++ b/httpclient_test.go
@@ -109,9 +109,11 @@ func TestHttpClient(t *testing.T) {
 	starter.Do(func() { setupMockServer(t) })
 
 	transport := &Transport{
-		ConnectTimeout:   1 * time.Second,
-		RequestTimeout:   5 * time.Second,
-		ReadWriteTimeout: 3 * time.Second,
+		ConnectTimeout:     1 * time.Second,
+		RequestTimeout:     5 * time.Second,
+		ReadWriteTimeout:   3 * time.Second,
+		TCPWriteBufferSize: 64 * 1024,
+		TCPReadBufferSize:  64 * 1024,
 	}
 	client := &http.Client{Transport: transport}
 


### PR DESCRIPTION
This is an advanced option for advanced users who want
to tune low level TCP parameters to try and squeeze out more performance. Especially in the WAN environment.