### PR TITLE
add copyright line to LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,7 @@
+The MIT License (MIT)
+
+Copyright (c) 2012 Matt Reiferson
+
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
 in the Software without restriction, including without limitation the rights


### PR DESCRIPTION
I got here trying to add improved certificate handling to Kubernetes- your package is a dependency of Google's [certificate-transparency](https://github.com/google/certificate-transparency) which is in turn a dependency of [cfssl](https://github.com/cloudflare/cfssl). There's a Kubernetes build script that is literally grepping for the "Copyright" line to assemble a combined license file and my pre-commit tests fail without it. Would you mind adding one?